### PR TITLE
Parameterize apiBaseUrl to allow use of Humio Community endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ import HumioTransport from 'humio-winston';
 const logger = winston.createLogger({
     format: winston.format.simple(),
     transports: [
-        // The only required option is your Humio ingest token
+        // The only required option is your Humio ingest token.
+        // apiBaseUrl is optional. Use to override default API base URL of https://cloud.humio.com
         new HumioTransport({
             ingestToken: '<YOUR INGEST TOKEN HERE>'
         }),
@@ -24,6 +25,7 @@ const logger = winston.createLogger({
 
 logger.info('Hello, world!');
 ```
+
 
 ### Tags
 

--- a/src/humio-winston.ts
+++ b/src/humio-winston.ts
@@ -6,6 +6,13 @@ const UNSTRUCTURE_API_ENDPOINT = '/api/v1/ingest/humio-unstructured';
 
 export interface HumioTransportOptions extends TransportStreamOptions {
     ingestToken: string;
+
+    /**
+     * Specify a specific URL for the Humio service.
+     * Default is https://cloud.humio.com. 
+     * For community use https://cloud.community.humio.com.
+     */
+    apiBaseUrl?: string;
     callback?: (err?: Error) => void;
     tags?: { [key: string]: string }
 }
@@ -18,10 +25,12 @@ export class HumioError extends Error {
 
 export default class HumioTransport extends Transport {
     private options: HumioTransportOptions;
+    private readonly apiBaseUrl: string;
 
     constructor(options: HumioTransportOptions) {
         super(options);
         this.options = options;
+        this.apiBaseUrl = options.apiBaseUrl || API_BASE_URL;
     }
 
     public log(info: any, callback: () => void): any {
@@ -42,7 +51,7 @@ export default class HumioTransport extends Transport {
 
     private async sendIngestRequest(endpoint: string, requestBody: any) {
         try {
-            const res = await fetch(API_BASE_URL + endpoint, {
+            const res = await fetch(this.apiBaseUrl + endpoint, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
Parameterizes apiBaseUrl, allowing use of the Humio Community endpoint at https://cloud.community.humio.com (or any other endpoint) as well as https://cloud.humio.com.

Backward compatible as the new field in `HumioTransportOptions`  is optional. 